### PR TITLE
Just use native Python virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 private/
 .Python
 env/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+SHELL:= bash
+PY:= python3.11
+VENV:= .venv
+
+vb:= $(VENV)/bin/
+
+define vrun
+	source $(vb)activate && $(1)
+endef
+
+.PHONY: requirements
+.PHONY: clean
+
+requirements: $(vb)pip requirements.txt
+	$(call vrun,pip --require-virtualenv \
+	  install --requirement=requirements.txt)
+
+$(vb)pip: $(vb)activate
+	$(call vrun,pip --require-virtualenv \
+	  list --format=freeze \
+	  |grep -oE '^[^=]+' \
+	  |xargs pip install --upgrade)
+
+$(vb)activate:
+	$(PY) -m venv $(VENV)
+
+clean:
+	rm -fr $(VENV)


### PR DESCRIPTION
 - just type `make` to create it
 - or type `make clean` to delete it

For those that don't want to fiddle with heavyweight/slow packaging.

Works on linux, MacOS, and WSL.